### PR TITLE
Heaps 1.6.1 support + fixes for Haxe 4

### DIFF
--- a/spriter/definitions/CharacterMap.hx
+++ b/spriter/definitions/CharacterMap.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/CharacterMap.hx
+++ b/spriter/definitions/CharacterMap.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -11,14 +11,14 @@ class CharacterMap
 	public var name:String;
     public var maps:Array<MapInstruction>;
 	
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
 		maps = new Array<MapInstruction>();
 		
-		id = Std.parseInt(fast.att.id);
-		name = fast.att.name;
+		id = Std.parseInt(xml.att.id);
+		name = xml.att.name;
 		
-		for (m in fast.nodes.map)
+		for (m in xml.nodes.map)
 		{
 			maps.push(new MapInstruction(m));
 		}

--- a/spriter/definitions/EventlineKey.hx
+++ b/spriter/definitions/EventlineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/EventlineKey.hx
+++ b/spriter/definitions/EventlineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -9,11 +9,11 @@ class EventlineKey
 {
 	public var id:Int;
 	public var time:Int = 0;
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
-		if(fast != null){
-			id = fast.has.id ? Std.parseInt(fast.att.id) : 0;
-			time = fast.has.time ? Std.parseInt(fast.att.time) : 0;
+		if(xml != null){
+			id = xml.has.id ? Std.parseInt(xml.att.id) : 0;
+			time = xml.has.time ? Std.parseInt(xml.att.time) : 0;
 		}
 	}
 	public function copy ():EventlineKey

--- a/spriter/definitions/MainlineKey.hx
+++ b/spriter/definitions/MainlineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 import spriter.engine.SpriterEngineParam;
 
 /**
@@ -13,20 +13,20 @@ class MainlineKey
     public var boneRefs:Array<Ref>; // <bone_ref> tags
     public var objectRefs:Array<Ref>; // <object_ref> tags 
 	
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
 		boneRefs = new Array<Ref>();
 		objectRefs = new Array<Ref>();
 		
-		id = Std.parseInt(fast.att.id);
-		time = fast.has.time ? Std.parseInt(fast.att.time) : 0;
+		id = Std.parseInt(xml.att.id);
+		time = xml.has.time ? Std.parseInt(xml.att.time) : 0;
 		
-		for (br in fast.nodes.bone_ref)
+		for (br in xml.nodes.bone_ref)
 		{
 			boneRefs.push(new Ref(br));
 		}
 		
-		for (or in fast.nodes.object_ref)
+		for (or in xml.nodes.object_ref)
 		{
 			objectRefs.push(new Ref(or));
 		}

--- a/spriter/definitions/MainlineKey.hx
+++ b/spriter/definitions/MainlineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 import spriter.engine.SpriterEngineParam;
 
 /**

--- a/spriter/definitions/MapInstruction.hx
+++ b/spriter/definitions/MapInstruction.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/MapInstruction.hx
+++ b/spriter/definitions/MapInstruction.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -12,12 +12,12 @@ class MapInstruction
     public var tarFolder:Int;
     public var tarFile:Int;
 	
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
-		folder = Std.parseInt(fast.att.folder);
-		file = Std.parseInt(fast.att.file);
-		tarFolder = fast.has.target_folder ? Std.parseInt(fast.att.target_folder) : -1;
-		tarFile = fast.has.target_file ? Std.parseInt(fast.att.target_file) : -1;
+		folder = Std.parseInt(xml.att.folder);
+		file = Std.parseInt(xml.att.file);
+		tarFolder = xml.has.target_folder ? Std.parseInt(xml.att.target_folder) : -1;
+		tarFile = xml.has.target_file ? Std.parseInt(xml.att.target_file) : -1;
 	}
 	
 }

--- a/spriter/definitions/Metaline.hx
+++ b/spriter/definitions/Metaline.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/Metaline.hx
+++ b/spriter/definitions/Metaline.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -9,13 +9,13 @@ import haxe.xml.Fast;
 //Internal helpers
 #if (haxe_ver < 3.3)
 typedef ConstructibleKey = {
-  public function new(fast:Fast):Void;
+  public function new(xml:Access):Void;
 }
 #end
  
 @:generic
 #if (haxe_ver >= 3.3)
-class Metaline<T:haxe.Constraints.Constructible<Fast->Void>> {
+class Metaline<T:haxe.Constraints.Constructible<Access->Void>> {
 #else
 class Metaline<T:ConstructibleKey> {
 #end
@@ -24,14 +24,14 @@ class Metaline<T:ConstructibleKey> {
 	public var name:String;
 	public var keys:Array<T>;
 	
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
-		if(fast != null){
-			id = fast.has.def ? Std.parseInt(fast.att.def) : fast.has.id ? Std.parseInt(fast.att.id) : -1;
-			if (fast.has.name)
-				name = fast.att.name;
+		if(xml != null){
+			id = xml.has.def ? Std.parseInt(xml.att.def) : xml.has.id ? Std.parseInt(xml.att.id) : -1;
+			if (xml.has.name)
+				name = xml.att.name;
 			keys = [];
-			for (key in fast.nodes.key)
+			for (key in xml.nodes.key)
 			{
 				keys.push(new T(key));
 			}

--- a/spriter/definitions/Quadrilateral.hx
+++ b/spriter/definitions/Quadrilateral.hx
@@ -5,6 +5,8 @@ import openfl.geom.Point;
 import flambe.math.Point;
 #elseif luxe
 typedef Point = phoenix.Vector;
+#elseif heaps
+typedef Point = h2d.col.Point;
 #end
 
 /**

--- a/spriter/definitions/Ref.hx
+++ b/spriter/definitions/Ref.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/Ref.hx
+++ b/spriter/definitions/Ref.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -13,13 +13,13 @@ class Ref
     public var key:Int;
 	public var z_index:Int;
 	
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
-		id = Std.parseInt(fast.att.id);
-		parent = fast.has.parent ? Std.parseInt(fast.att.parent) : -1;
-		timeline = Std.parseInt(fast.att.timeline);
-		key = Std.parseInt(fast.att.key);
-		z_index = fast.has.z_index ? Std.parseInt(fast.att.z_index) : 0;
+		id = Std.parseInt(xml.att.id);
+		parent = xml.has.parent ? Std.parseInt(xml.att.parent) : -1;
+		timeline = Std.parseInt(xml.att.timeline);
+		key = Std.parseInt(xml.att.key);
+		z_index = xml.has.z_index ? Std.parseInt(xml.att.z_index) : 0;
 	}
 	
 }

--- a/spriter/definitions/ScmlObject.hx
+++ b/spriter/definitions/ScmlObject.hx
@@ -1,7 +1,7 @@
 package spriter.definitions;
 
 import haxe.Unserializer;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/ScmlObject.hx
+++ b/spriter/definitions/ScmlObject.hx
@@ -1,7 +1,7 @@
 package spriter.definitions;
 
 import haxe.Unserializer;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -45,12 +45,12 @@ class ScmlObject
 			entities = new Map<String,SpriterEntity>();
 			entitiesName = [];
 			
-			var fast = new Fast(source.firstElement());
+			var xml = new Access(source.firstElement());
 			
-			if (fast.att.scml_version != "1.0")
+			if (xml.att.scml_version != "1.0")
 				trace("Warning, unsupported format.");
 			
-			for(el in fast.elements)
+			for(el in xml.elements)
 			{
 				if(el.name == "folder")
 				{

--- a/spriter/definitions/SoundlineKey.hx
+++ b/spriter/definitions/SoundlineKey.hx
@@ -1,6 +1,6 @@
 package spriter.definitions;
 
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -11,12 +11,12 @@ class SoundlineKey extends EventlineKey
 
 	public var folder:Int;
 	public var file:Int;
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
-		super(fast);
-		if(fast != null){
-			folder = Std.parseInt(fast.node.object.att.folder);
-			file = Std.parseInt(fast.node.object.att.file);
+		super(xml);
+		if(xml != null){
+			folder = Std.parseInt(xml.node.object.att.folder);
+			file = Std.parseInt(xml.node.object.att.file);
 		}
 	}
 	

--- a/spriter/definitions/SoundlineKey.hx
+++ b/spriter/definitions/SoundlineKey.hx
@@ -1,6 +1,6 @@
 package spriter.definitions;
 
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/SpriterAnimation.hx
+++ b/spriter/definitions/SpriterAnimation.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 import spriter.definitions.SpriterAnimation.LoopType;
 import spriter.definitions.SpriterTimeline.ObjectType;
 import spriter.engine.Spriter;

--- a/spriter/definitions/SpriterAnimation.hx
+++ b/spriter/definitions/SpriterAnimation.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 import spriter.definitions.SpriterAnimation.LoopType;
 import spriter.definitions.SpriterTimeline.ObjectType;
 import spriter.engine.Spriter;
@@ -48,18 +48,18 @@ class SpriterAnimation
 	
 	
 	
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
 		mainlineKeys = [];
 		timelines = [];
 		
 		
-		id = Std.parseInt(fast.att.id);
-		name = fast.att.name;
-		length = Std.parseInt(fast.att.length);
-		//loopType = fast.has.looping ? Type.createEnum(LoopType, fast.att.looping.toUpperCase()) : LOOPING;
-		if (fast.has.looping) {
-			if (fast.att.looping == "true") {
+		id = Std.parseInt(xml.att.id);
+		name = xml.att.name;
+		length = Std.parseInt(xml.att.length);
+		//loopType = xml.has.looping ? Type.createEnum(LoopType, xml.att.looping.toUpperCase()) : LOOPING;
+		if (xml.has.looping) {
+			if (xml.att.looping == "true") {
 				loopType = LOOPING;
 			}else {
 				loopType = NO_LOOPING;
@@ -68,53 +68,53 @@ class SpriterAnimation
 			loopType = LOOPING;
 		}
 		
-		for (mk in fast.node.mainline.nodes.key)
+		for (mk in xml.node.mainline.nodes.key)
 		{
 			mainlineKeys.push(new MainlineKey(mk));
 		}
 		
-		for (t in fast.nodes.timeline)
+		for (t in xml.nodes.timeline)
 		{
 			timelines.push(new SpriterTimeline(t));
 		}
 		#if !SPRITER_NO_SOUND
-		if (fast.hasNode.soundline)
+		if (xml.hasNode.soundline)
 		{
 			soundlines = [];
-			for (tag in fast.nodes.soundline)
+			for (tag in xml.nodes.soundline)
 			{
 				soundlines.push(new Metaline<SoundlineKey>(tag));
 			}
 		}
 		#end
 		#if !SPRITER_NO_EVENT
-		if (fast.hasNode.eventline)
+		if (xml.hasNode.eventline)
 		{
 			eventlines = [];
-			for (tag in fast.nodes.eventline)
+			for (tag in xml.nodes.eventline)
 			{
 				eventlines.push(new Metaline<EventlineKey>(tag));
 			}
 		}
 		#end
-		if (fast.hasNode.meta)
+		if (xml.hasNode.meta)
 		{
-			fast = fast.node.meta;
+			xml = xml.node.meta;
 			#if !SPRITER_NO_TAG
-			if (fast.hasNode.tagline)
+			if (xml.hasNode.tagline)
 			{
 				taglines = [];
-				for (tag in fast.node.tagline.nodes.key)
+				for (tag in xml.node.tagline.nodes.key)
 				{
 					taglines.push(new TaglineKey(tag));
 				}
 			}
 			#end
 			#if !SPRITER_NO_VAR
-			if (fast.hasNode.varline)
+			if (xml.hasNode.varline)
 			{
 				varlines = [];
-				for (currVar in fast.nodes.varline)
+				for (currVar in xml.nodes.varline)
 				{
 					varlines.push(new Metaline<VarlineKey>(currVar));
 				}

--- a/spriter/definitions/SpriterBox.hx
+++ b/spriter/definitions/SpriterBox.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -13,15 +13,15 @@ class SpriterBox
 	public var width:Float;
 	public var height:Float;
 	
-	public function new(fast:Fast = null) 
+	public function new(xml:Access = null) 
 	{
-		if(fast != null){
-			name = fast.att.name;
-			pivotX = fast.has.pivot_x ? Std.parseFloat(fast.att.pivot_x) : 0;
-			pivotY = fast.has.pivot_y ? Std.parseFloat(fast.att.pivot_y) : 0;
+		if(xml != null){
+			name = xml.att.name;
+			pivotX = xml.has.pivot_x ? Std.parseFloat(xml.att.pivot_x) : 0;
+			pivotY = xml.has.pivot_y ? Std.parseFloat(xml.att.pivot_y) : 0;
 			
-			width = fast.has.w ? Std.parseFloat(fast.att.w) : 0;
-			height = fast.has.h ? Std.parseFloat(fast.att.h) : 0;
+			width = xml.has.w ? Std.parseFloat(xml.att.w) : 0;
+			height = xml.has.h ? Std.parseFloat(xml.att.h) : 0;
 		}
 	}
 	

--- a/spriter/definitions/SpriterBox.hx
+++ b/spriter/definitions/SpriterBox.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/SpriterEntity.hx
+++ b/spriter/definitions/SpriterEntity.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 #if !SPRITER_NO_VAR
 import spriter.vars.Variable;
 import spriter.vars.VariableFloat;
@@ -25,7 +25,7 @@ class SpriterEntity
 	#end
 
 	
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
 		characterMaps = new Map<String,CharacterMap>();
 		animations = new Map<String,SpriterAnimation>();
@@ -35,17 +35,17 @@ class SpriterEntity
 		variables = new Array<Variable<Dynamic>>();
 		#end
 		
-		id = Std.parseInt(fast.att.id);
-		name = fast.att.name;
+		id = Std.parseInt(xml.att.id);
+		name = xml.att.name;
 		
-		for (cm in fast.nodes.character_map)
+		for (cm in xml.nodes.character_map)
 		{
 			characterMaps.set(cm.att.name, new CharacterMap(cm));
 		}
 		
 		#if !SPRITER_NO_VAR
-		if(fast.hasNode.var_defs){
-			for (v in fast.node.var_defs.elements)
+		if(xml.hasNode.var_defs){
+			for (v in xml.node.var_defs.elements)
 			{
 				switch(v.att.type)
 				{
@@ -60,13 +60,13 @@ class SpriterEntity
 		}
 		#end
 		
-		for (oi in fast.nodes.obj_info)
+		for (oi in xml.nodes.obj_info)
 		{
 			boxes_info.set(oi.att.name, new SpriterBox(oi));
 		}
 		
 		
-		for (a in fast.nodes.animation)
+		for (a in xml.nodes.animation)
 		{
 			animations.set(a.att.name, new SpriterAnimation(a));
 			animationsName.push(a.att.name);

--- a/spriter/definitions/SpriterEntity.hx
+++ b/spriter/definitions/SpriterEntity.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 #if !SPRITER_NO_VAR
 import spriter.vars.Variable;
 import spriter.vars.VariableFloat;

--- a/spriter/definitions/SpriterFile.hx
+++ b/spriter/definitions/SpriterFile.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/SpriterFile.hx
+++ b/spriter/definitions/SpriterFile.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -14,16 +14,16 @@ class SpriterFile
 	public var width:Float;
 	public var height:Float;
 	
-	public function new(fast:Fast = null) 
+	public function new(xml:Access = null) 
 	{
-		if(fast != null){
-			id = Std.parseInt(fast.att.id);
-			name = fast.att.name;
-			pivotX = fast.has.pivot_x ? Std.parseFloat(fast.att.pivot_x) : 0;
-			pivotY = fast.has.pivot_y ? Std.parseFloat(fast.att.pivot_y) : 1;
+		if(xml != null){
+			id = Std.parseInt(xml.att.id);
+			name = xml.att.name;
+			pivotX = xml.has.pivot_x ? Std.parseFloat(xml.att.pivot_x) : 0;
+			pivotY = xml.has.pivot_y ? Std.parseFloat(xml.att.pivot_y) : 1;
 			
-			width = fast.has.width ? Std.parseFloat(fast.att.width) : 0;
-			height = fast.has.height ? Std.parseFloat(fast.att.height) : 0;
+			width = xml.has.width ? Std.parseFloat(xml.att.width) : 0;
+			height = xml.has.height ? Std.parseFloat(xml.att.height) : 0;
 		}
 	}
 	

--- a/spriter/definitions/SpriterFolder.hx
+++ b/spriter/definitions/SpriterFolder.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/SpriterFolder.hx
+++ b/spriter/definitions/SpriterFolder.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -13,17 +13,17 @@ class SpriterFolder
     public var files:Array<SpriterFile>;
 	
 	
-	public function new(fast:Fast = null) 
+	public function new(xml:Access = null) 
 	{
 		files = new Array<SpriterFile>();
 		
-		if(fast != null){
-			id = Std.parseInt(fast.att.id);
-			if(fast.hasNode.name){
-				name = fast.att.name;
+		if(xml != null){
+			id = Std.parseInt(xml.att.id);
+			if(xml.hasNode.name){
+				name = xml.att.name;
 			}
 			
-			for (f in fast.nodes.file)
+			for (f in xml.nodes.file)
 			{
 				files.push(new SpriterFile(f));
 			}

--- a/spriter/definitions/SpriterTimeline.hx
+++ b/spriter/definitions/SpriterTimeline.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 import spriter.definitions.SpriterTimeline.ObjectType;
 
 /**

--- a/spriter/definitions/SpriterTimeline.hx
+++ b/spriter/definitions/SpriterTimeline.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 import spriter.definitions.SpriterTimeline.ObjectType;
 
 /**
@@ -24,16 +24,16 @@ class SpriterTimeline
     public var objectType:ObjectType; // enum : SPRITE,BONE,BOX,POINT,SOUND,ENTITY,VARIABLE
     public var keys:Array<TimelineKey>;
 	
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
 		keys = new Array<TimelineKey>();
 		
-		id = Std.parseInt(fast.att.id);
-		name = fast.has.name ? fast.att.name : "";
-		objectType = fast.has.object_type ? Type.createEnum(ObjectType, fast.att.object_type.toUpperCase()) : ObjectType.SPRITE;
+		id = Std.parseInt(xml.att.id);
+		name = xml.has.name ? xml.att.name : "";
+		objectType = xml.has.object_type ? Type.createEnum(ObjectType, xml.att.object_type.toUpperCase()) : ObjectType.SPRITE;
 		
 					
-		for (k in fast.nodes.key)
+		for (k in xml.nodes.key)
 		{
 			keys.push(new TimelineKey(k, objectType));
 		}

--- a/spriter/definitions/TaglineKey.hx
+++ b/spriter/definitions/TaglineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/TaglineKey.hx
+++ b/spriter/definitions/TaglineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -10,13 +10,13 @@ class TaglineKey
 	public var id:Int;
 	public var time:Int = 0;
 	public var t:Array<Int>;
-	public function new(fast:Fast = null) 
+	public function new(xml:Access = null) 
 	{
-		if(fast != null){
-			id = fast.has.id ? Std.parseInt(fast.att.id) : 0;
-			time = fast.has.time ? Std.parseInt(fast.att.time) : 0;
+		if(xml != null){
+			id = xml.has.id ? Std.parseInt(xml.att.id) : 0;
+			time = xml.has.time ? Std.parseInt(xml.att.time) : 0;
 			t = [];
-			for (tag in fast.nodes.tag)
+			for (tag in xml.nodes.tag)
 			{
 				t.push(Std.parseInt(tag.att.t));
 			}

--- a/spriter/definitions/TimelineKey.hx
+++ b/spriter/definitions/TimelineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 import spriter.definitions.SpriterTimeline.ObjectType;
 import spriter.definitions.TimelineKey.CurveType;
 import spriter.engine.Spriter;

--- a/spriter/definitions/TimelineKey.hx
+++ b/spriter/definitions/TimelineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 import spriter.definitions.SpriterTimeline.ObjectType;
 import spriter.definitions.TimelineKey.CurveType;
 import spriter.engine.Spriter;
@@ -56,28 +56,28 @@ class TimelineKey
 		return c;
 	}
 	
-	public function new(fast:Fast, type:ObjectType) 
+	public function new(xml:Access, type:ObjectType) 
 	{
 		this.objectType = type;
 		
-		if (fast != null) {
-			id = fast.has.id ? Std.parseInt(fast.att.id) : 0;
-			time = fast.has.time ? Std.parseInt(fast.att.time) : 0;
-			curveType = fast.has.curve_type ? Type.createEnum(CurveType, fast.att.curve_type.toUpperCase()) : CurveType.LINEAR;
-			c1 = fast.has.c1 ? Std.parseFloat(fast.att.c1) : 0;
-			c2 = fast.has.c2 ? Std.parseFloat(fast.att.c2) : 0;
-			c3 = fast.has.c3 ? Std.parseFloat(fast.att.c3) : 0;
-			c4 = fast.has.c4 ? Std.parseFloat(fast.att.c4) : 0;
+		if (xml != null) {
+			id = xml.has.id ? Std.parseInt(xml.att.id) : 0;
+			time = xml.has.time ? Std.parseInt(xml.att.time) : 0;
+			curveType = xml.has.curve_type ? Type.createEnum(CurveType, xml.att.curve_type.toUpperCase()) : CurveType.LINEAR;
+			c1 = xml.has.c1 ? Std.parseFloat(xml.att.c1) : 0;
+			c2 = xml.has.c2 ? Std.parseFloat(xml.att.c2) : 0;
+			c3 = xml.has.c3 ? Std.parseFloat(xml.att.c3) : 0;
+			c4 = xml.has.c4 ? Std.parseFloat(xml.att.c4) : 0;
 			
-			var child:Fast;
+			var child:Access;
 			if (objectType != VARIABLE)
 			{
-				var spin = fast.has.spin ? Std.parseInt(fast.att.spin) : 1;
+				var spin = xml.has.spin ? Std.parseInt(xml.att.spin) : 1;
 			
-				if (fast.hasNode.object){
-					child = fast.node.object;
+				if (xml.hasNode.object){
+					child = xml.node.object;
 				}else {
-					child = fast.node.bone;
+					child = xml.node.bone;
 				}
 				
 				var x = child.has.x ? Std.parseFloat(child.att.x) : 0;

--- a/spriter/definitions/VarlineKey.hx
+++ b/spriter/definitions/VarlineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Access;
+import spriter.xml.Access;
 
 /**
  * ...

--- a/spriter/definitions/VarlineKey.hx
+++ b/spriter/definitions/VarlineKey.hx
@@ -1,5 +1,5 @@
 package spriter.definitions;
-import haxe.xml.Fast;
+import haxe.xml.Access;
 
 /**
  * ...
@@ -8,11 +8,11 @@ import haxe.xml.Fast;
 class VarlineKey extends TimelineKey
 {
 	public var value:String;
-	public function new(fast:Fast) 
+	public function new(xml:Access) 
 	{
-		if(fast != null){
-			value = fast.att.val;
+		if(xml != null){
+			value = xml.att.val;
 		}
-		super(fast, VARIABLE);
+		super(xml, VARIABLE);
 	}
 }

--- a/spriter/library/AbstractLibrary.hx
+++ b/spriter/library/AbstractLibrary.hx
@@ -1,4 +1,5 @@
 package spriter.library;
+import haxe.io.Path;
 import spriter.definitions.PivotInfo;
 import spriter.definitions.Quadrilateral;
 import spriter.definitions.SpatialInfo;
@@ -116,6 +117,11 @@ class AbstractLibrary
 	public function destroy():Void
 	{
 		
+	}
+
+	private function getFullPath(relativePath:String):String
+	{
+		return Path.join([_basePath, relativePath]);
 	}
 	
 }

--- a/spriter/util/AtlasUtil.hx
+++ b/spriter/util/AtlasUtil.hx
@@ -78,7 +78,7 @@ class AtlasUtil
 		var tilesheet:TilesheetEx = new TilesheetEx(img, textureScale);
 		
 		var ins = new Point(0, 0);
-		var x = new haxe.xml.Access( Xml.parse(xml).firstElement() );
+		var x = new spriter.xml.Access( Xml.parse(xml).firstElement() );
 
 		for (texture in x.nodes.Sub)
 		{

--- a/spriter/util/AtlasUtil.hx
+++ b/spriter/util/AtlasUtil.hx
@@ -78,7 +78,7 @@ class AtlasUtil
 		var tilesheet:TilesheetEx = new TilesheetEx(img, textureScale);
 		
 		var ins = new Point(0, 0);
-		var x = new haxe.xml.Fast( Xml.parse(xml).firstElement() );
+		var x = new haxe.xml.Access( Xml.parse(xml).firstElement() );
 
 		for (texture in x.nodes.Sub)
 		{

--- a/spriter/util/ColorUtils.hx
+++ b/spriter/util/ColorUtils.hx
@@ -13,7 +13,7 @@ class ColorUtils
 	 * @param	factor	 Number from 0.0 to 1.0.
 	 * @return 	The lightened color
 	 */
-	inline public static inline function multiplyAlpha(factor:Float = 1, color:Int = 0xffffffff):Int
+ 	public static inline function multiplyAlpha(factor:Float = 1, color:Int = 0xffffffff):Int
 	{
 		var r:Int = getRed(color);
 		var g:Int = getGreen(color);
@@ -21,19 +21,23 @@ class ColorUtils
 
 		return makeFromARGB(factor, r, g, b);
 	}
-	inline public static inline function getRed(Color:Int):Int
+
+	public static inline function getRed(Color:Int):Int
 	{
 		return Color >> 16 & 0xFF;
 	}
-	inline public static inline function getGreen(Color:Int):Int
+
+	public static inline function getGreen(Color:Int):Int
 	{
 		return Color >> 8 & 0xFF;
 	}
-	inline public static inline function getBlue(Color:Int):Int
+
+	public static inline function getBlue(Color:Int):Int
 	{
 		return Color & 0xFF;
 	}
-	inline public static inline function makeFromARGB(alpha:Float = 1.0, r:Int, g:Int, b:Int):Int
+	
+	public static inline function makeFromARGB(alpha:Float = 1.0, r:Int, g:Int, b:Int):Int
 	{
 		return (Std.int((alpha > 1) ? alpha : (alpha * 255)) & 0xFF) << 24 | (r & 0xFF) << 16 | (g & 0xFF) << 8 | (b & 0xFF);
 	}

--- a/spriter/util/MathUtils.hx
+++ b/spriter/util/MathUtils.hx
@@ -120,7 +120,7 @@ class MathUtils
 		var d2:Float;
 		var i:Int;
 
-		// First try a few iterations of Newton's method -- normally very fast.
+		// First try a few iterations of Newton's method -- normally very xml.
 		for (i in 0...8) 
 		{
 			x2 = sampleCurve(ax, bx, cx, t2) - x; 

--- a/spriter/util/MathUtils.hx
+++ b/spriter/util/MathUtils.hx
@@ -120,7 +120,7 @@ class MathUtils
 		var d2:Float;
 		var i:Int;
 
-		// First try a few iterations of Newton's method -- normally very xml.
+		// First try a few iterations of Newton's method -- normally very fast.
 		for (i in 0...8) 
 		{
 			x2 = sampleCurve(ax, bx, cx, t2) - x; 

--- a/spriter/xml/Access.hx
+++ b/spriter/xml/Access.hx
@@ -1,0 +1,8 @@
+package spriter.xml;
+
+// haxe.xml.Access replaced haxe.xml.Fast in Haxe 4
+#if (haxe_ver >= 4)
+typedef Access = haxe.xml.Access;
+#else
+typedef Access = haxe.xml.Fast;
+#end


### PR DESCRIPTION
- Fixed Heaps driver implementation. Works with Heaps 1.6.1 (probably some earlier versions as well).
- Changed xml.Fast usages to xml.Access when targeting Haxe 4 to fix deprecation warnings. Compiling with earlier Haxe versions will still use Fast. Renamed variables from 'fast' to 'xml.'
- Removed duplicate inline specifiers.