### PR TITLE
Add nextFrame and prevFrame method

### DIFF
--- a/spriter/definitions/SpatialInfo.hx
+++ b/spriter/definitions/SpatialInfo.hx
@@ -61,6 +61,12 @@ class SpatialInfo implements ISpriterPooled
 		return this;
 	}
 	
+	/**
+	 * Convenient method to set both x and y in one line.
+	 * @param	x
+	 * @param	y
+	 * @return
+	 */
 	public function setPos(x:Float = 0, y:Float = 0):SpatialInfo
 	{
 		this.x = x; 
@@ -68,6 +74,11 @@ class SpatialInfo implements ISpriterPooled
 		return this;
 	}
 	
+	/**
+	 * Convenient method to set both scaleX and scaleY.
+	 * @param	scale
+	 * @return
+	 */
 	public function setScale(scale:Float):SpatialInfo
 	{
 		this.scaleX = scale; 
@@ -75,10 +86,10 @@ class SpatialInfo implements ISpriterPooled
 		return this;
 	}
 	/**
-	 * 
+	 * Get SpatialInfo modified by parent.
 	 * @param	parentInfo
 	 * @param	out if null, this method will override this SpatialInfo
-	 * @return
+	 * @return SpatialInfo modified with parent values. Use out if specified.
 	 */
 	public function unmapFromParent(parentInfo:SpatialInfo, out:SpatialInfo = null):SpatialInfo
     {
@@ -115,10 +126,18 @@ class SpatialInfo implements ISpriterPooled
 		return out;
     }
 	
+	/**
+	 * Create a new SpatialInfo with values from this.
+	 * @return new SpatialInfo
+	 */
 	inline public function copy():SpatialInfo
 	{
 		return new SpatialInfo(x, y, angle, scaleX, scaleY, a, spin);
 	}
+	/**
+	 * Copy SpatialInfo from other values
+	 * @param	out spatialInfo to copy
+	 */
 	public function clone(out:SpatialInfo):Void
 	{
 		out.init(x, y, angle, scaleX, scaleY, a, spin);//initializing the out object with the values of this object

--- a/spriter/definitions/SpriterAnimation.hx
+++ b/spriter/definitions/SpriterAnimation.hx
@@ -306,6 +306,7 @@ class SpriterAnimation
 		}
 		#end
 		
+		//we store the trigger time only when everything has been tested (if not we'll only trigger first event...)
 		if(triggerResult)
 			_triggerTime = mainKey.time;
 		else if (_triggerTime != mainKey.time)
@@ -329,7 +330,6 @@ class SpriterAnimation
 	{
 		if (eventTime == keyTime)
 		{
-			//TODO on jumping on a frame on individual spriters, we may update(0) to have better control of times, but this won't trigger anything because elapsed time equals 0
 			if (newTime - elapsedTime <= keyTime && _triggerTime != keyTime)
 			{
 				return true;

--- a/spriter/engine/Spriter.hx
+++ b/spriter/engine/Spriter.hx
@@ -405,6 +405,32 @@ class Spriter
 		return nextTime;
 	}
 	
+	public function getPrevKeyTime():Int 
+	{
+		var i = currentAnimation.mainlineKeys.length - 1;
+		
+		var prevTime = currentAnimation.mainlineKeys[i].time;
+		while(i >= 0) {
+		  if(currentAnimation.mainlineKeys[i].time < timeMS)
+			{
+				prevTime = currentAnimation.mainlineKeys[i].time;
+				break;
+			}
+		  i--;
+		}
+		return prevTime;
+	}
+	
+	public function nextFrame():Void
+	{
+		timeMS = getNextKeyTime();
+	}
+	
+	public function prevFrame():Void
+	{
+		timeMS = getPrevKeyTime();
+	}
+	
 	public function reverse(value:Bool = true):Spriter
 	{
 		if (value)

--- a/spriter/engine/Spriter.hx
+++ b/spriter/engine/Spriter.hx
@@ -132,7 +132,7 @@ class Spriter
 			
 			if (currentAnimation.loopType == LOOPING)
 			{
-					normalizedTime += Std.int(elapsedMS * playbackSpeed);
+					normalizedTime = timeMS;
 					if (normalizedTime >= currentAnimation.length)//forward
 					{
 						normalizedTime -= currentAnimation.length;
@@ -148,7 +148,7 @@ class Spriter
 			}
 		}
 		//even if paused we need to draw it
-		currentAnimation.setCurrentTime(normalizedTime, Std.int(MathUtils.fabs(elapsedMS * playbackSpeed)), library, this, currentEntity, info);
+		currentAnimation.setCurrentTime(normalizedTime, timeMS, library, this, currentEntity, info);
 		//callback
 		if (currentAnimation.loopType == LOOPING)
 		{

--- a/spriter/engine/Spriter.hx
+++ b/spriter/engine/Spriter.hx
@@ -10,7 +10,6 @@ import spriter.definitions.SpriterEntity;
 import spriter.definitions.SpriterFile;
 import spriter.definitions.SpriterFolder;
 import spriter.library.AbstractLibrary;
-import spriter.util.MathUtils;
 import spriter.util.SpriterUtil;
 import spriter.vars.Variable;
 #if SPRITER_CUSTOM_MAP
@@ -387,6 +386,25 @@ class Spriter
 			normalizedTime = timeMS = currentAnimation.length;
 		}
 	}
+	
+	public function getNextKeyTime():Int
+	{
+		var nextTime = 0;
+		
+		var len:Int = currentAnimation.mainlineKeys.length;
+		for (m in 0...len)
+		{
+			if(currentAnimation.mainlineKeys[m].time > timeMS)
+			{
+				nextTime = currentAnimation.mainlineKeys[m].time;
+				break;
+			}
+			
+		}
+		
+		return nextTime;
+	}
+	
 	public function reverse(value:Bool = true):Spriter
 	{
 		if (value)

--- a/spriter/util/MathUtils.hx
+++ b/spriter/util/MathUtils.hx
@@ -6,7 +6,8 @@ package spriter.util;
  */
 class MathUtils
 {
-	inline static public function fabs(n:Float):Float
+	@:generic
+	inline static public function abs<T:Float>(n:T):T
 	{
 		if(n >= 0) {
 			return n;
@@ -118,19 +119,18 @@ class MathUtils
 		var t2:Float = x;
 		var x2:Float;
 		var d2:Float;
-		var i:Int;
 
 		// First try a few iterations of Newton's method -- normally very fast.
 		for (i in 0...8) 
 		{
 			x2 = sampleCurve(ax, bx, cx, t2) - x; 
-			if(fabs(x2) < epsilon) {
+			if(abs(x2) < epsilon) {
 				return t2;
 			} 
 
 			d2 = sampleCurveDerivativeX(ax, bx, cx, t2); 
 
-			if(fabs(d2) < 1e-6) {
+			if(abs(d2) < 1e-6) {
 				break;
 			} 
 
@@ -155,7 +155,7 @@ class MathUtils
 		while(t0 < t1) 
 		{
 			x2 = sampleCurve(ax, bx, cx, t2); 
-			if(fabs(x2-x) < epsilon) {
+			if(abs(x2-x) < epsilon) {
 				return t2;
 			} 
 			if(x > x2) {


### PR DESCRIPTION
There are now a `nextFrame` and `prevFrame `methods that allows to move frame by frame all spriters independendly (as long as you update with no elapsed time : `update(0)` )
There is now a correlation between `timeMS `and `normalizedTime` so both values are bounds together.
so it allows to change from any time and Spriter calculate the normalizedTime accordingly.
There is now a `progress `property to easily set an animation at a specific progression

Breaking change: change `timeMS `by time and make `normalizedTime `read only.

**BUG to fix: complete() calls unstable**